### PR TITLE
Add toggle to recalculate uploaded file statistics

### DIFF
--- a/src/Markowitz.Web/Pages/Index.cshtml
+++ b/src/Markowitz.Web/Pages/Index.cshtml
@@ -24,6 +24,7 @@
   <input type="hidden" asp-for="ActiveTab" id="active-tab-field" />
   <input type="hidden" asp-for="TargetCardExpanded" id="target-card-state" />
   <input type="hidden" asp-for="PerAssetExpanded" id="per-asset-state" />
+  <input type="hidden" asp-for="UseIntersectionStatistics" id="intersection-statistics-state" />
   <button type="submit" name="action" value="upload" id="upload-submit" class="d-none" formnovalidate>Upload</button>
   <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
@@ -65,6 +66,18 @@
               }
             </tbody>
           </table>
+        </div>
+        <div class="d-flex justify-content-between align-items-center mt-2">
+          <small class="text-muted">
+            @(Model.UseIntersectionStatistics
+              ? "Statistics are calculated using the shared date range."
+              : "Statistics are calculated using the full available range.")
+          </small>
+          <button type="submit" name="action" value="toggle-intersection" class="btn btn-sm btn-outline-secondary" formnovalidate>
+            @(Model.UseIntersectionStatistics
+              ? "Show full-range statistics"
+              : "Show shared-range statistics")
+          </button>
         </div>
       </div>
     }


### PR DESCRIPTION
## Summary
- add UI toggle below the uploaded files table to switch between full-period and shared-range statistics
- persist toggle state via a bound property and process the action server-side without triggering optimization
- reuse the aligned timeline used for optimization to recalculate per-file statistics when the shared range is selected

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1dd90d9b4832a849cbdc9e0f0e1c3